### PR TITLE
Simple email format validation

### DIFF
--- a/lib/agoneum/account/user.ex
+++ b/lib/agoneum/account/user.ex
@@ -36,6 +36,7 @@ defmodule Agoneum.Account.User do
 
   defp common_changeset(changeset) do
     changeset
+    |> validate_format(:email, ~r/@/)
     |> validate_length(:password, min: 6)
     |> validate_confirmation(:password, message: "does not match password")
     |> hash_password

--- a/test/agoneum/account/account_test.exs
+++ b/test/agoneum/account/account_test.exs
@@ -6,8 +6,8 @@ defmodule Agoneum.AccountTest do
   describe "users" do
     alias Agoneum.Account.User
 
-    @valid_attrs %{email: "some email", name: "some name", password: "some password"}
-    @update_attrs %{email: "some updated email", name: "some updated name", password: "some updated password"}
+    @valid_attrs %{email: "email@agoneum.com", name: "some name", password: "some password"}
+    @update_attrs %{email: "updated@agoneum.com", name: "some updated name", password: "some updated password"}
     @invalid_attrs %{email: nil, name: nil, password_hash: nil}
 
     def user_fixture(attrs \\ %{}) do
@@ -55,7 +55,7 @@ defmodule Agoneum.AccountTest do
 
     test "create_user/1 with valid data creates a user" do
       assert {:ok, %User{} = user} = Account.create_user(@valid_attrs)
-      assert user.email == "some email"
+      assert user.email == "email@agoneum.com"
       assert user.name == "some name"
     end
 
@@ -67,7 +67,7 @@ defmodule Agoneum.AccountTest do
       user = user_fixture()
       assert {:ok, user} = Account.update_user(user, @update_attrs)
       assert %User{} = user
-      assert user.email == "some updated email"
+      assert user.email == "updated@agoneum.com"
       assert user.name == "some updated name"
     end
 
@@ -79,7 +79,7 @@ defmodule Agoneum.AccountTest do
 
     test "update_user/2 without a password update does not update the password" do
       user = user_fixture()
-      assert {:ok, updated_user} = Account.update_user(user, %{email: "new_email@example.com"})
+      assert {:ok, updated_user} = Account.update_user(user, %{email: "new_email@agoneum.com"})
       assert user.password_hash == updated_user.password_hash
     end
 

--- a/test/agoneum/web/controllers/registration_controller_test.exs
+++ b/test/agoneum/web/controllers/registration_controller_test.exs
@@ -13,4 +13,19 @@ defmodule Agoneum.Web.RegistrationControllerTest do
     conn = post conn, registration_path(conn, :create), user: @invalid_attrs
     assert html_response(conn, 422) =~ "Sign Up"
   end
+
+  test "throws an error if the email address is not formatted correctly", %{conn: conn} do
+    conn = post conn, registration_path(conn, :create), user: %{email: "email"}
+    assert html_response(conn, 422) =~ "has invalid format"
+  end
+
+  test "throws an error if the password is too short", %{conn: conn} do
+    conn = post conn, registration_path(conn, :create), user: %{password: "abcd"}
+    assert html_response(conn, 422) =~ "should be at least 6 character(s)"
+  end
+
+  test "throws an error if the password confirmation does not match the password", %{conn: conn} do
+    conn = post conn, registration_path(conn, :create), user: %{password: "abcd", password_confirmation: "efgh"}
+    assert html_response(conn, 422) =~ "does not match password"
+  end
 end

--- a/test/agoneum/web/controllers/registration_controller_test.exs
+++ b/test/agoneum/web/controllers/registration_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule Agoneum.Web.RegistrationControllerTest do
   use Agoneum.Web.ConnCase
 
-  @create_attrs %{email: "some email", name: "some name", password: "some password"}
+  @create_attrs %{email: "email@agoneum.com", name: "some name", password: "some password"}
   @invalid_attrs %{email: nil, name: nil, password: nil}
 
   test "creates user and redirects to the main page", %{conn: conn} do

--- a/test/agoneum/web/controllers/session_controller_test.exs
+++ b/test/agoneum/web/controllers/session_controller_test.exs
@@ -4,8 +4,8 @@ defmodule Agoneum.Web.SessionControllerTest do
   alias Agoneum.Account
 
   describe "UI login" do
-    @create_attrs %{name: "some name", email: "some email", password: "some password"}
-    @login_attrs %{email: "some email", password: "some password"}
+    @create_attrs %{name: "some name", email: "email@agoneum.com", password: "some password"}
+    @login_attrs %{email: "email@agoneum.com", password: "some password"}
     @invalid_attrs %{email: nil, password: nil}
 
     test "shows the login form", %{conn: conn} do
@@ -31,8 +31,8 @@ defmodule Agoneum.Web.SessionControllerTest do
   end
 
   describe "API login" do
-    @create_attrs %{name: "some name", email: "some email", password: "some password"}
-    @login_attrs %{email: "some email", password: "some password"}
+    @create_attrs %{name: "some name", email: "email@agoneum.com", password: "some password"}
+    @login_attrs %{email: "email@agoneum.com", password: "some password"}
     @invalid_attrs %{email: nil, password: nil}
 
     setup %{conn: conn} do


### PR DESCRIPTION
Super basic validation. We could also add a check to make sure a `.` appears somewhere after the `@`